### PR TITLE
FREYA-1187: Update year in MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 SciLifeLab Data Centre
+Copyright (c) 2025 SciLifeLab Data Centre
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This probably should not be merged until after the other open PR (with codeowners), hence why it's draft. 
