### PR TITLE
Adds script to fetch and filter ongoing research projects from SweCRIS API

### DIFF
--- a/Ongoing_projects/get_ongoing_projects.py
+++ b/Ongoing_projects/get_ongoing_projects.py
@@ -144,7 +144,7 @@ if __name__ == "__main__":
     }
 
     # Save to JSON
-    output_file = "Ongoing_projects/ongoing_research_projects.json"
+    output_file = "ongoing_research_projects.json"
     with open(output_file, "w") as f:
         json.dump(output_data, f, indent=2)
 

--- a/Ongoing_projects/get_ongoing_projects.py
+++ b/Ongoing_projects/get_ongoing_projects.py
@@ -5,6 +5,7 @@ import time
 import logging
 import os  # Import the os module
 from dotenv import load_dotenv  # Import load_dotenv
+import re # Add this at the top
 
 # Load environment variables from .env file
 load_dotenv()
@@ -79,7 +80,11 @@ def match_topics(project):
 
     matched_topics = []
     for topic, keywords in TOPIC_KEYWORDS.items():
-        if any(keyword.lower() in text for keyword in keywords):
+        # Create a regex pattern for the topic's keywords, matching whole words
+        # We escape potential regex special characters in keywords just in case
+        # and join them with '|' (OR), surrounded by word boundaries '\b'
+        pattern = r"\b(" + "|".join(re.escape(kw.lower()) for kw in keywords) + r")\b"
+        if re.search(pattern, text):
             matched_topics.append(topic)
     return matched_topics
 
@@ -139,7 +144,7 @@ if __name__ == "__main__":
     }
 
     # Save to JSON
-    output_file = "Ongoing_projects/data/ongoing_research_projects.json"
+    output_file = "Ongoing_projects/ongoing_research_projects.json"
     with open(output_file, "w") as f:
         json.dump(output_data, f, indent=2)
 

--- a/README.md
+++ b/README.md
@@ -11,3 +11,23 @@ This folder contains all of the scripts used to update the [covid publications d
 #### EBI Indexing
 
 This folder contains all of the scripts used to update [EBI index JSON](https://blobserver.dc.scilifelab.se/blob/pathogens_portal_EBI_index.json/info) file. This will be run as a dialy cronjob in `dc-dynamic`. The index file is parsed by EBI (on regular basis) and the info about dataset/dashboards are put up in the main EU pathogens portal.
+
+#### Ongoing Projects
+
+This directory contains scripts and data related to fetching and processing information about ongoing research projects funded by the Swedish Research Council (Vetenskapsrådet).
+
+##### `getOngoingProjects.py`
+
+This script fetches project data from the SweCRIS API (`https://swecris-api.vr.se/v1/projects`). It performs the following steps:
+
+1.  **Loads API Token:** Reads the `SWECRIS_API_TOKEN` from environment variables. For local development, create a `.env` file in the project root and add the token like this:
+    ```
+    SWECRIS_API_TOKEN="your_actual_token"
+    ```
+2.  **Fetches Projects:** Retrieves all project data from the API.
+3.  **Filters Ongoing Projects:** Filters the projects to include only those whose start and end dates encompass the current date.
+4.  **Matches Topics:** Identifies projects related to specific scientific topics (e.g., Antibiotic resistance, COVID-19, Influenza) based on keywords found in the project title or abstract.
+5.  **Formats Output:** Structures the relevant information for each matched project (funder, title, funding amount, principal investigator, dates, URL).
+6.  **Saves Data:** Saves the filtered and formatted project data into `Ongoing_projects/data/ongoing_research_projects.json` JSON file.
+
+

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This folder contains all of the scripts used to update [EBI index JSON](https://
 
 This directory contains scripts and data related to fetching and processing information about ongoing research projects funded by the Swedish Research Council (Vetenskapsrådet).
 
-##### `getOngoingProjects.py`
+##### `get_ongoing_projects.py`
 
 This script fetches project data from the SweCRIS API (`https://swecris-api.vr.se/v1/projects`). It performs the following steps:
 
@@ -28,6 +28,6 @@ This script fetches project data from the SweCRIS API (`https://swecris-api.vr.s
 3.  **Filters Ongoing Projects:** Filters the projects to include only those whose start and end dates encompass the current date.
 4.  **Matches Topics:** Identifies projects related to specific scientific topics (e.g., Antibiotic resistance, COVID-19, Influenza) based on keywords found in the project title or abstract.
 5.  **Formats Output:** Structures the relevant information for each matched project (funder, title, funding amount, principal investigator, dates, URL).
-6.  **Saves Data:** Saves the filtered and formatted project data into `Ongoing_projects/data/ongoing_research_projects.json` JSON file.
+6.  **Saves Data:** Saves the filtered and formatted project data into `Ongoing_projects/ongoing_research_projects.json` JSON file.
 
 

--- a/ongoing_projects/getOngoingProjects.py
+++ b/ongoing_projects/getOngoingProjects.py
@@ -1,0 +1,134 @@
+import requests
+import datetime
+import json
+import time
+import logging
+
+# --- Constants ---
+API_URL = "https://swecris-api.vr.se/v1/projects"
+AUTH_TOKEN = "VRSwecrisAPI2024-1" # TODO: This is a testing token provided publically by VR. We need to get a new token for our own use.
+PAGE_SIZE = 100
+TODAY = datetime.date.today()
+UNKNOWN = "Unknown"
+
+# --- Topic keywords --- avoid acronymn
+TOPIC_KEYWORDS = {
+    "Antibiotic resistance": ["antibiotic resistance", "antimicrobial resistance", "antimicrobial"],
+    "COVID-19": ["covid","SARS-CoV-2"],
+    "Enteric viruses": ["norovirus", "rotavirus", "enteric virus"],
+    "Infectious diseases": ["infectious disease", "pathogen"],
+    "Influenza": ["influenza", "influensa", "H1N1", "H3N2"],
+    "Mpox": ["mpox", "monkeypox"],
+    "Respiratory Syncytial Virus (RSV)": ["respiratory syncytial virus"]
+}
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+
+# --- Functions ---
+def fetch_all_projects():
+    """Fetch all projects from the SweCRIS API."""
+    logging.info("Fetching projects from SweCRIS...")
+    try:
+        response = requests.get(
+            API_URL,
+            headers={
+                "accept": "application/json",
+                "Authorization": f"Bearer {AUTH_TOKEN}"
+            }
+        )
+        response.raise_for_status()
+    except requests.RequestException as e:
+        logging.error(f"Failed to fetch projects: {e}")
+        return []
+
+    projects = response.json()
+    logging.info(f"Fetched {len(projects)} projects.")
+    return projects
+
+
+def is_ongoing(project):
+    """Check if a project is ongoing based on its start and end dates."""
+    try:
+        start = datetime.datetime.strptime(project["projectStartDate"].split()[0], "%Y-%m-%d").date()
+        end = datetime.datetime.strptime(project["projectEndDate"].split()[0], "%Y-%m-%d").date()
+        return start <= TODAY <= end
+    except (KeyError, ValueError) as e:
+        logging.warning(f"Error parsing dates for project {project.get('projectId', UNKNOWN)}: {e}")
+        return False
+
+
+def match_topics(project):
+    """Match project topics based on keywords."""
+    text = " ".join([
+        str(project.get("projectTitleEn") or project.get("projectTitleSv", "")),
+        str(project.get("projectAbstractEn", ""))
+    ]).lower()
+
+    matched_topics = []
+    for topic, keywords in TOPIC_KEYWORDS.items():
+        if any(keyword.lower() in text for keyword in keywords):
+            matched_topics.append(topic)
+    return matched_topics
+
+
+def format_project(project, topics):
+    """Format a project for output."""
+    funder = project.get("fundingOrganisationNameEn", UNKNOWN)
+    title = project.get("projectTitleEn") or project.get("projectTitleSv", UNKNOWN)
+
+    amount = f"{project.get('fundingsSek', 0):,} kr".replace(",", " ")
+    start = project.get("projectStartDate", "").split()[0]
+    end = project.get("projectEndDate", "").split()[0]
+    project_id = project.get("projectId", "")
+    url = f"https://www.vr.se/english/swecris.html#/project/{project_id}"
+
+    pi = UNKNOWN
+    affiliation = UNKNOWN
+    for person in project.get("peopleList", []):
+        if person.get("roleEn") == "Principal Investigator":
+            pi = person.get("fullName", pi)
+            affiliation = project.get("coordinatingOrganisationNameEn", affiliation)
+            break
+
+    return {
+        "topic": topics,
+        "funder": funder,
+        "project_title": title,
+        "funding_amount": amount,
+        "pi": pi,
+        "pi_affiliation": affiliation,
+        "startdate": start,
+        "enddate": end,
+        "url": url
+    }
+
+
+# --- Main Execution ---
+if __name__ == "__main__":
+    all_projects = fetch_all_projects()
+
+    # Filter ongoing projects
+    ongoing_projects = [p for p in all_projects if is_ongoing(p)]
+
+    # Filter by topic
+    final_output = []
+    for project in ongoing_projects:
+        topics = match_topics(project)
+        if topics:
+            formatted_project = format_project(project, topics)
+            if formatted_project:
+                final_output.append(formatted_project)
+
+    # Prepare the final JSON structure
+    output_data = {
+        "last_updated": TODAY.isoformat(),
+        "projects": final_output
+    }
+
+    # Save to JSON
+    output_file = "ongoing_projects/data/ongoing_research_projects.json"
+    with open(output_file, "w") as f:
+        json.dump(output_data, f, indent=2)
+
+    logging.info(f"✅ Done. Saved {len(final_output)} topic-matched ongoing projects to: {output_file}")

--- a/ongoing_projects/getOngoingProjects.py
+++ b/ongoing_projects/getOngoingProjects.py
@@ -3,10 +3,22 @@ import datetime
 import json
 import time
 import logging
+import os  # Import the os module
+from dotenv import load_dotenv  # Import load_dotenv
+
+# Load environment variables from .env file
+load_dotenv()
 
 # --- Constants ---
 API_URL = "https://swecris-api.vr.se/v1/projects"
-AUTH_TOKEN = "VRSwecrisAPI2024-1" # TODO: This is a testing token provided publically by VR. We need to get a new token for our own use.
+# Get the token from environment variable
+# To run locally, create a .env file in the project root
+# and add the line: SWECRIS_API_TOKEN="your_actual_token"
+AUTH_TOKEN = os.environ.get("SWECRIS_API_TOKEN")
+# Add a check to ensure the token was loaded
+if not AUTH_TOKEN:
+    raise ValueError("Error: SWECRIS_API_TOKEN environment variable not set or .env file not found.")
+
 PAGE_SIZE = 100
 TODAY = datetime.date.today()
 UNKNOWN = "Unknown"

--- a/ongoing_projects/getOngoingProjects.py
+++ b/ongoing_projects/getOngoingProjects.py
@@ -139,7 +139,7 @@ if __name__ == "__main__":
     }
 
     # Save to JSON
-    output_file = "ongoing_projects/data/ongoing_research_projects.json"
+    output_file = "Ongoing_projects/data/ongoing_research_projects.json"
     with open(output_file, "w") as f:
         json.dump(output_data, f, indent=2)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 crossrefapi==1.5.0
 requests==2.32.3
+python-dotenv==1.1.0


### PR DESCRIPTION
This pull request introduces a new script `ongoing_projects/getOngoingProjects.py` to fetch ongoing research projects from the SweCRIS API, filter them based on their status and topics, and save the results to a JSON file. 
Closes: [FREYA-165](https://scilifelab.atlassian.net/browse/FREYA-165)